### PR TITLE
Theme not using config's `languageCode`

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en-US{{ end }}">
 <head>
 <meta charset="utf-8">
 {{ .Hugo.Generator }}


### PR DESCRIPTION
Default language should be pulled from Hugo config.  Was hard-coded otherwise.
