### PR TITLE
added ability to hide a page from index

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ In this theme you can add variables to your site config file. The following is t
 	  email     = "rakuishi@gmail.com"
 	  analytics = "UA-12345678-9"
 
+`copyright` may contain safe HTML, such as a link to a license.
+
 ### Hide pages from the homepage list
 
 To exclude a page from the list on the homepage (e.g. `content/about.md`), set the following property in the page's frontmatter:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ In this theme you can add variables to your site config file. The following is t
 	  email     = "rakuishi@gmail.com"
 	  analytics = "UA-12345678-9"
 
+### Hide pages from the homepage list
+
+To exclude a page from the list on the homepage (e.g. `content/about.md`), set the following property in the page's frontmatter:
+
+	hidefromhome = true
+
 ## License
 
 MIT License

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,0 +1,7 @@
++++
+date = "now()"
+slug = ""
+tags = ["", ""]
+title = ""
+
++++

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ partial "header.html" . }}
 
 	<main role="main">
-{{ range .Data.Pages }}
+{{ range (where .Data.Pages ".Params.hidefromhome" "!=" "true") }}
 		<article itemscope itemtype="http://schema.org/Blog">
 			<h2 class="entry-title" itemprop="headline"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
 			<span class="entry-meta"><time itemprop="datePublished" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "January 02, 2006" }}</time></span>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,7 +7,7 @@
 			{{ with .Site.Params.facebook }}<a href="{{ . }}" target="_blank">Facebook</a></span>{{ end }}
 			{{ with .Site.Params.github }}<a href="{{ . }}" target="_blank">GitHub</a></span>{{ end }}
 		</div>
-		<div class="copyright">Copyright &copy; {{ .Site.Params.copyright }}</div>
+		<div class="copyright">Copyright &copy; {{ .Site.Params.copyright | safeHTML }}</div>
 	</footer>
 
 </div>


### PR DESCRIPTION
I found it annoying that the template cannot currently hide content from the list on the index page.

This patch contains a simple flag to enable content hiding. I'm using it for my 'About' page.
