### PR TITLE
removed erroneous closing `span` tags from footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,10 +2,10 @@
 	<footer role="contentinfo">
 		<div class="hr"></div>
 		<div class="footer-link">
-			{{ with .Site.Params.email }}<a href="mailto:{{ . }}" target="_blank">Email</a></span>{{ end }}
-			{{ with .Site.Params.twitter }}<a href="{{ . }}" target="_blank">Twitter</a></span>{{ end }}
-			{{ with .Site.Params.facebook }}<a href="{{ . }}" target="_blank">Facebook</a></span>{{ end }}
-			{{ with .Site.Params.github }}<a href="{{ . }}" target="_blank">GitHub</a></span>{{ end }}
+			{{ with .Site.Params.email }}<a href="mailto:{{ . }}" target="_blank">Email</a>{{ end }}
+			{{ with .Site.Params.twitter }}<a href="{{ . }}" target="_blank">Twitter</a>{{ end }}
+			{{ with .Site.Params.facebook }}<a href="{{ . }}" target="_blank">Facebook</a>{{ end }}
+			{{ with .Site.Params.github }}<a href="{{ . }}" target="_blank">GitHub</a>{{ end }}
 		</div>
 		<div class="copyright">Copyright &copy; {{ .Site.Params.copyright | safeHTML }}</div>
 	</footer>


### PR DESCRIPTION
I have removed the trailing `</span>`s in the footer with no opening tags. It looks like they were missed as part of a clean-up.
