### PR TITLE
Update template variable names

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,12 +7,12 @@
 			{{ with .Site.Params.facebook }}<a href="{{ . }}" target="_blank">Facebook</a>{{ end }}
 			{{ with .Site.Params.github }}<a href="{{ . }}" target="_blank">GitHub</a>{{ end }}
 		</div>
-		<div class="copyright">Copyright &copy; {{ .Site.Params.copyright | safeHTML }}</div>
+		<div class="copyright">Copyright &copy; {{ .Site.Copyright | safeHTML }}</div>
 	</footer>
 
 </div>
 
-{{ with .Site.Params.analytics }}<script>
+{{ with .Site.GoogleAnalytics }}<script>
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)


### PR DESCRIPTION
.Site.Params.copyright to .Site.Copyright

(which fixes issue with safeHTML missing an argument)

and

.Site.Params.analytics to .Site.GoogleAnalytics

See https://gohugo.io/templates/variables/

.Site.GoogleAnalytics A string representing your tracking code for Google
Analytics as defined in the site configuration.

.Site.Copyright A string representing the copyright of your web site as
defined in the site configuration.
