### PR TITLE
Update config example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ In this theme you can add variables to your site config file. The following is t
 	languageCode = "ja"
 	title = "rakuishi.com"
 	author = "rakuishi"
+	copyright = "rakuishi All rights reserved."
 
 	[params]
 	  logo      = "/images/logo.jpg"
-	  copyright = "rakuishi All rights reserved."
 	  twitter   = "https://twitter.com/rakuishi07"
 	  facebook  = "https://www.facebook.com/ochiishikoichiro"
 	  github    = "https://github.com/rakuishi/"


### PR DESCRIPTION
c9dfacc0acb14d8418ae97f43c1d69242debda5c updated footer.html to pull copyright
text from .Site.copyright instead of .Site.Params.copyright. Update README.md's
example config file to match.
