### PR TITLE
Add support for GitLab in footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ In this theme you can add variables to your site config file. The following is t
 	  twitter   = "https://twitter.com/rakuishi07"
 	  facebook  = "https://www.facebook.com/ochiishikoichiro"
 	  github    = "https://github.com/rakuishi/"
+	  gitlab    = "https://gitlab.com/rakuishi/"
 	  email     = "rakuishi@gmail.com"
 	  analytics = "UA-12345678-9"
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,6 +6,7 @@
 			{{ with .Site.Params.twitter }}<a href="{{ . }}" target="_blank">Twitter</a>{{ end }}
 			{{ with .Site.Params.facebook }}<a href="{{ . }}" target="_blank">Facebook</a>{{ end }}
 			{{ with .Site.Params.github }}<a href="{{ . }}" target="_blank">GitHub</a>{{ end }}
+			{{ with .Site.Params.gitlab }}<a href="{{ . }}" target="_blank">GitLab</a>{{ end }}
 		</div>
 		<div class="copyright">Copyright &copy; {{ .Site.Copyright | safeHTML }}</div>
 	</footer>


### PR DESCRIPTION
This is a small addition to the footer to add support for linking to the user's personal [GitLab](https://gitlab.com/) account.

GitLab is being adopted rapidly by developers and they also have [examples](https://gitlab.com/pages/hugo) for building sites with Hugo. My personal site is on GitLab and it would be great to have support for GitLab links, hence this change.

Here is a screenshot demonstrating the change:

![add_gitlab_to_footer](https://cloud.githubusercontent.com/assets/4828793/23084138/cde3c890-f558-11e6-8155-d3d80c2f99d1.png)

I added the link after the GitHub link for consistency.