### PR TITLE
Fix config example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ In this theme you can add variables to your site config file. The following is t
 	title = "rakuishi.com"
 	author = "rakuishi"
 	copyright = "rakuishi All rights reserved."
+	googleanalytics = "UA-12345678-9"
 
 	[params]
 	  logo      = "/images/logo.jpg"
@@ -27,7 +28,6 @@ In this theme you can add variables to your site config file. The following is t
 	  facebook  = "https://www.facebook.com/ochiishikoichiro"
 	  github    = "https://github.com/rakuishi/"
 	  email     = "rakuishi@gmail.com"
-	  analytics = "UA-12345678-9"
 
 `copyright` may contain safe HTML, such as a link to a license.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ In this theme you can add variables to your site config file. The following is t
 	title = "rakuishi.com"
 	author = "rakuishi"
 	copyright = "rakuishi All rights reserved."
+    googleanalytics = "UA-12345678-9"
 
 	[params]
 	  logo      = "/images/logo.jpg"
@@ -27,7 +28,6 @@ In this theme you can add variables to your site config file. The following is t
 	  facebook  = "https://www.facebook.com/ochiishikoichiro"
 	  github    = "https://github.com/rakuishi/"
 	  email     = "rakuishi@gmail.com"
-	  analytics = "UA-12345678-9"
 
 `copyright` may contain safe HTML, such as a link to a license.
 


### PR DESCRIPTION
Due to the change made in commit [c9dfacc](https://github.com/rakuishi/hugo-zen/commit/c9dfacc0acb14d8418ae97f43c1d69242debda5c), remove "analytics" parameter
from config example and add "googleanalytics" parameter in global
options.

This change is similar to #9.